### PR TITLE
Wait for error message to be printed before exiting process

### DIFF
--- a/bin/tap-bail.js
+++ b/bin/tap-bail.js
@@ -7,7 +7,14 @@ var p = parser(function(results){
 });
 
 p.on('assert', function(assert){
-  if (!assert.ok) process.exit(1);
+  if (!assert.ok) {
+    // Only abort after, error message was printed
+    p.on('extra', function(extra) {
+        if(extra.indexOf('...') !== -1) {
+            process.exit(1);
+        }
+    });
+  }
 });
 
 process.stdin.pipe(process.stdout);


### PR DESCRIPTION
Hey, 
tap-bail exits as soon as "Not ok" is found. This prohibits tap to print the error message in my case. So I added another check to wait for the line with "..." after the error message.
Cheers
